### PR TITLE
WindSpeed fix

### DIFF
--- a/bin/user/wmr89.py
+++ b/bin/user/wmr89.py
@@ -68,7 +68,7 @@ class WMR89Driver(weewx.drivers.AbstractDevice):
     # the default map is for the wview schema
     DEFAULT_MAP = {
         'pressure': 'pressure',
-        'windSpeed': 'wind_avg',
+        'windSpeed': 'wind_speed',
         'windDir': 'wind_dir',
         'windGust': 'wind_gust',
         'windchill': 'wind_chill',


### PR DESCRIPTION
Not sure if I have different firmware on my WMR89, but wind speed is sent as "wind_speed" in the data stream from my device. After this change WeeWX correctly shows wind data for me.